### PR TITLE
Add retry interceptor to work around 429 HTTP errors

### DIFF
--- a/lib/client/retryInterceptor.js
+++ b/lib/client/retryInterceptor.js
@@ -16,7 +16,8 @@ function sleep(seconds) {
  */
 module.exports = (customAxios) => {
     // on 429 Too Many Requests responses retry after 5 seconds
-    customAxios.interceptors.response.use(response => response,
+    customAxios.interceptors.response.use(
+        response => response,
         async (error) => {
             if (error.response && error.response.status === 429) {
                 await sleep(5);
@@ -25,7 +26,8 @@ module.exports = (customAxios) => {
             }
 
             return Promise.reject(error);
-        });
+        }
+    );
 
     return customAxios;
 };

--- a/lib/client/retryInterceptor.js
+++ b/lib/client/retryInterceptor.js
@@ -1,0 +1,31 @@
+/**
+ * Sleeps for given amount of seconds
+ *
+ * @param seconds
+ * @returns {Promise}
+ */
+function sleep(seconds) {
+    return new Promise(resolve => setTimeout(() => resolve(), seconds * 1000));
+}
+
+/**
+ * Attach the retry interceptor to the axios instance to transparently ensure all requests are going through eventually.
+ *
+ * @param {Object} customAxios axios instance
+ * @return {Object}
+ */
+module.exports = (customAxios) => {
+    // on 429 Too Many Requests responses retry after 5 seconds
+    customAxios.interceptors.response.use(response => response,
+        async (error) => {
+            if (error.response && error.response.status === 429) {
+                await sleep(5);
+
+                return customAxios(error.config);
+            }
+
+            return Promise.reject(error);
+        });
+
+    return customAxios;
+};

--- a/lib/client/shopwareAuthentication.js
+++ b/lib/client/shopwareAuthentication.js
@@ -68,7 +68,7 @@ module.exports = (customAxios, user, pass) => {
     // on 401 Unauthenticated responses (token expired) first obtain a new accessToken and then retry the request once
     customAxios.interceptors.response.use(response => response,
         (error) => {
-            if (error.response.status === 401 && error.config && !error.config.isRetryRequest) {
+            if (error.response && error.response.status === 401 && error.config && !error.config.isRetryRequest) {
                 error.config.isRetryRequest = true;
                 accessToken = null;
                 customAxios.emitter.emit('info', 'Renewing auth data...');

--- a/lib/client/shopwareAuthentication.js
+++ b/lib/client/shopwareAuthentication.js
@@ -66,7 +66,7 @@ module.exports = (customAxios, user, pass) => {
     );
 
     // on 401 Unauthenticated responses (token expired) first obtain a new accessToken and then retry the request once
-    customAxios.interceptors.response.use(async response => response,
+    customAxios.interceptors.response.use(response => response,
         (error) => {
             if (error.response.status === 401 && error.config && !error.config.isRetryRequest) {
                 error.config.isRetryRequest = true;

--- a/lib/client/shopwareAuthentication.js
+++ b/lib/client/shopwareAuthentication.js
@@ -46,27 +46,29 @@ module.exports = (customAxios, user, pass) => {
     let accessToken = null;
 
     // if no acessToken is stored yet, first login and obtain one
-    customAxios.interceptors.request.use(async (config) => {
-        if (!config.noToken) {
-            if (!accessToken) {
-                // Login to get an access token
-                accessToken = await login(user, pass, customAxios);
+    customAxios.interceptors.request.use(
+        async (config) => {
+            if (!config.noToken) {
+                if (!accessToken) {
+                    // Login to get an access token
+                    accessToken = await login(user, pass, customAxios);
+                }
+
+                if (config.headers) {
+                    config.headers['X-Shopware-Token'] = accessToken;
+                } else {
+                    config.headers = { 'X-Shopware-Token': accessToken };
+                }
             }
 
-            if (config.headers) {
-                config.headers['X-Shopware-Token'] = accessToken;
-            } else {
-                config.headers = { 'X-Shopware-Token': accessToken };
-            }
-        }
-
-        return config;
-    },
+            return config;
+        },
         error => Promise.reject(error)
     );
 
     // on 401 Unauthenticated responses (token expired) first obtain a new accessToken and then retry the request once
-    customAxios.interceptors.response.use(response => response,
+    customAxios.interceptors.response.use(
+        response => response,
         (error) => {
             if (error.response && error.response.status === 401 && error.config && !error.config.isRetryRequest) {
                 error.config.isRetryRequest = true;
@@ -77,7 +79,8 @@ module.exports = (customAxios, user, pass) => {
             }
 
             return Promise.reject(error);
-        });
+        }
+    );
 
     return customAxios;
 };

--- a/lib/client/shopwareAuthentication.js
+++ b/lib/client/shopwareAuthentication.js
@@ -35,9 +35,9 @@ async function login(username, password, axios) {
 /**
  * Attach authentication interceptors to the axios instance to transparently ensure all requests are authenticated.
  *
- * @param {Object} axios instance
- * @param {String} username
- * @param {String} password
+ * @param {Object} customAxios axios instance
+ * @param {String} user username
+ * @param {String} pass password
  * @return {Object}
  */
 module.exports = (customAxios, user, pass) => {

--- a/lib/client/shopwareStoreClient.js
+++ b/lib/client/shopwareStoreClient.js
@@ -3,6 +3,7 @@ const spinnerInterceptors = require('./spinnerInterceptors');
 const shopwareAuthentication = require('./shopwareAuthentication');
 
 const baseURL = 'https://api.shopware.com/';
+const timeout = 2 * 60 * 1000; // 2 minutes
 
 /**
  * Create the axios instance, attach the emitter to it and register all interceptors.
@@ -15,6 +16,7 @@ const baseURL = 'https://api.shopware.com/';
 module.exports = (user, pass, emitter) => {
     const customAxios = axios.create({
         baseURL,
+        timeout,
     });
     customAxios.emitter = emitter;
     spinnerInterceptors(customAxios);

--- a/lib/client/shopwareStoreClient.js
+++ b/lib/client/shopwareStoreClient.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const spinnerInterceptors = require('./spinnerInterceptors');
 const shopwareAuthentication = require('./shopwareAuthentication');
+const retryInterceptor = require('./retryInterceptor');
 
 const baseURL = 'https://api.shopware.com/';
 const timeout = 2 * 60 * 1000; // 2 minutes
@@ -21,6 +22,7 @@ module.exports = (user, pass, emitter) => {
     customAxios.emitter = emitter;
     spinnerInterceptors(customAxios);
     shopwareAuthentication(customAxios, user, pass);
+    retryInterceptor(customAxios);
 
     return customAxios;
 };

--- a/lib/client/shopwareStoreClient.js
+++ b/lib/client/shopwareStoreClient.js
@@ -7,8 +7,8 @@ const baseURL = 'https://api.shopware.com/';
 /**
  * Create the axios instance, attach the emitter to it and register all interceptors.
  *
- * @param {String} username
- * @param {String} password
+ * @param {String} user username
+ * @param {String} pass password
  * @param {EventEmitter} emitter
  * @return {Object}
  */

--- a/lib/client/spinnerInterceptors.js
+++ b/lib/client/spinnerInterceptors.js
@@ -6,26 +6,32 @@
  */
 module.exports = (customAxios) => {
     // start the spinner on request start and stop it on request errors
-    customAxios.interceptors.request.use((config) => {
-        customAxios.emitter.emit('startHttpRequest');
+    customAxios.interceptors.request.use(
+        (config) => {
+            customAxios.emitter.emit('startHttpRequest');
 
-        return config;
-    }, (error) => {
-        customAxios.emitter.emit('endHttpRequest');
+            return config;
+        },
+        (error) => {
+            customAxios.emitter.emit('endHttpRequest');
 
-        return Promise.reject(error);
-    });
+            return Promise.reject(error);
+        }
+    );
 
     // stop the spinner on responses
-    customAxios.interceptors.response.use((response) => {
-        customAxios.emitter.emit('endHttpRequest');
+    customAxios.interceptors.response.use(
+        (response) => {
+            customAxios.emitter.emit('endHttpRequest');
 
-        return response;
-    }, (error) => {
-        customAxios.emitter.emit('endHttpRequest');
+            return response;
+        },
+        (error) => {
+            customAxios.emitter.emit('endHttpRequest');
 
-        return Promise.reject(error);
-    });
+            return Promise.reject(error);
+        }
+    );
 
     return customAxios;
 };


### PR DESCRIPTION
This PR will add a retry interceptor to constantly retry failed requests with HTTP error code 429 after 5 seconds each. Additionally a default timeout of generous 2 minutes has been added so no request is stuck forever.