### PR TITLE
Add dump-plugin subcommand to output all plugin information as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ You can also get complied HTML (which is the same as used by the `upload` comman
 
 `scs-commander compatibility -u <your_username> -p <technical_plugin_name> --min-version <shopware_version_string>`
 
+### Download and dump the plugin information
+
+`scs-commander dump-plugin -u <your_username> -p <technical_plugin_name> [-f <FORMAT>]`
+
+Currently the only supported output format is `json`.
+
 ## License
 
 [MIT](https://github.com/VIISON/scs-commander/blob/master/LICENSE)

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ Program
     .command('changelog', 'Echos a plugin zip file\'s changelog.')
     .command('compatibility', 'Updates the minimum Shopware version compatibility of all binaries of a plugin.')
     .command('description', 'Updates the plugin description of a supported locale.')
+    .command('dump-plugin', 'Outputs all information for a specified plugin.')
     .command('upload', 'Uploads a plugin zip file and makes it available for download.')
     .command('list', 'Lists all available plugins.', { isDefault: true })
     .parse(process.argv);

--- a/lib/commands/dumpPlugin.js
+++ b/lib/commands/dumpPlugin.js
@@ -14,7 +14,7 @@ Program
     .arguments('<file>')
     .option('-u, --username <username>', 'The shopware username.')
     .option('-p, --plugin <plugin>', 'The name of the plugin for which to output information')
-    .option('-t, --output-format <format>', 'Output in format <format>', 'json')
+    .option('-f, --format <format>', 'Output in format <format>', 'json')
     .parse(process.argv);
 
 
@@ -30,8 +30,8 @@ if (typeof Program.plugin === 'undefined') {
     console.error(Chalk.white.bgRed.bold('No plugin name given!'));
     process.exit(1);
 }
-if (Program.outputFormat !== 'json') {
-    console.error(Chalk.white.bgRed.bold(`Unsupported output format: ${Program.outputFormat}`));
+if (Program.format !== 'json') {
+    console.error(Chalk.white.bgRed.bold(`Unsupported output format: ${Program.format}`));
     process.exit(1);
 }
 

--- a/lib/commands/dumpPlugin.js
+++ b/lib/commands/dumpPlugin.js
@@ -41,6 +41,7 @@ async function main() {
         const commander = new ShopwareStoreCommander(Program.username, password);
         spinner(commander.logEmitter);
 
+        // Try to find the plugin
         const plugin = await commander.findPlugin(Program.plugin);
         if (!plugin) {
             process.exit(1);

--- a/lib/commands/dumpPlugin.js
+++ b/lib/commands/dumpPlugin.js
@@ -21,19 +21,22 @@ Program
 // Load an .env config if available
 require('../envLoader').loadConfig(Program);
 
+// Validate arguments
+if (typeof Program.username === 'undefined') {
+    console.error(Chalk.white.bgRed.bold('No username given!'));
+    process.exit(1);
+}
+if (typeof Program.plugin === 'undefined') {
+    console.error(Chalk.white.bgRed.bold('No plugin name given!'));
+    process.exit(1);
+}
+if (Program.outputFormat !== 'json') {
+    console.error(Chalk.white.bgRed.bold(`Unsupported output format: ${Program.outputFormat}`));
+    process.exit(1);
+}
+
 async function main() {
     try {
-        // Validate arguments
-        if (typeof Program.username === 'undefined') {
-            throw new Error('No username given!');
-        }
-        if (typeof Program.plugin === 'undefined') {
-            throw new Error('No plugin name given!');
-        }
-        if (Program.outputFormat !== 'json') {
-            throw new Error(`Unsupported output format: ${Program.outputFormat}`);
-        }
-
         const password = await getPassword(Program);
         const commander = new ShopwareStoreCommander(Program.username, password);
         spinner(commander.logEmitter);

--- a/lib/commands/dumpPlugin.js
+++ b/lib/commands/dumpPlugin.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const Chalk = require('chalk');
+const Program = require('commander');
+const ShopwareStoreCommander = require('../shopwareStoreCommander');
+const util = require('../util');
+const programVersion = require('../version');
+const spinner = require('../cliStatusIndicator');
+const getPassword = require('../passwordPrompt');
+
+// Define CLI
+Program
+    .version(programVersion)
+    .arguments('<file>')
+    .option('-u, --username <username>', 'The shopware username.')
+    .option('-p, --plugin <plugin>', 'The name of the plugin for which to output information')
+    .option('-t, --output-format <format>', 'Output in format <format>', 'json')
+    .parse(process.argv);
+
+
+// Load an .env config if available
+require('../envLoader').loadConfig(Program);
+
+async function main() {
+    try {
+        // Validate arguments
+        if (typeof Program.username === 'undefined') {
+            throw new Error('No username given!');
+        }
+        if (typeof Program.plugin === 'undefined') {
+            throw new Error('No plugin name given!');
+        }
+        if (Program.outputFormat !== 'json') {
+            throw new Error(`Unsupported output format: ${Program.outputFormat}`);
+        }
+
+        const password = await getPassword(Program);
+        const commander = new ShopwareStoreCommander(Program.username, password);
+        spinner(commander.logEmitter);
+
+        const plugin = await commander.findPlugin(Program.plugin);
+        if (!plugin) {
+            process.exit(1);
+        }
+
+        console.log(JSON.stringify(plugin, null, 4));
+    } catch (err) {
+        const errorMessage = `\u{1F6AB} Error: ${err.message}`;
+        util.showGrowlIfEnabled(errorMessage);
+        console.error(Chalk.white.bgRed.bold(errorMessage));
+        console.error(err);
+        process.exit(1);
+    }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "scs-commander-changelog": "./lib/commands/changelog.js",
         "scs-commander-compatibility": "./lib/commands/compatibility.js",
         "scs-commander-description": "./lib/commands/description.js",
+        "scs-commander-dump-plugin": "./lib/commands/dumpPlugin.js",
         "scs-commander-list": "./lib/commands/list.js",
         "scs-commander-upload": "./lib/commands/upload.js"
     },


### PR DESCRIPTION
This can easily be piped into other JSON-handling programs for automated processing.