### PR TITLE
Do not try to download the binaries

### DIFF
--- a/lib/commands/compatibility.js
+++ b/lib/commands/compatibility.js
@@ -45,7 +45,7 @@ async function main() {
         spinner(commander.logEmitter);
 
         // Try to find the plugin
-        const plugin = await commander.findPlugin(Program.plugin, []);
+        const plugin = await commander.findPlugin(Program.plugin);
         if (!plugin) {
             process.exit(1);
         }

--- a/lib/commands/compatibility.js
+++ b/lib/commands/compatibility.js
@@ -45,7 +45,7 @@ async function main() {
         spinner(commander.logEmitter);
 
         // Try to find the plugin
-        const plugin = await commander.findPlugin(Program.plugin, ['binaries']);
+        const plugin = await commander.findPlugin(Program.plugin, []);
         if (!plugin) {
             process.exit(1);
         }

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -94,7 +94,7 @@ async function main() {
         pluginInfo.addChangelog(pluginChangelog);
 
         // Try to find the plugin
-        let plugin = await commander.findPlugin(pluginInfo.getName(), ['binaries', 'reviews']);
+        let plugin = await commander.findPlugin(pluginInfo.getName(), ['reviews']);
         if (!plugin) {
             process.exit(1);
         }


### PR DESCRIPTION
Shopware changed their API so the binaries are now part of the original `GET plugin/{id}` request. Therefore, the scs-commander throws an error when we are trying to download them.

This pr remove the loading of the binaries as separate request.