### PR TITLE
Increase upload wait time to 5 minutes

### DIFF
--- a/lib/shopwareStoreCommander.js
+++ b/lib/shopwareStoreCommander.js
@@ -245,7 +245,7 @@ module.exports = class ShopwareStoreCommander {
             const updatedReview = reviews.data.find(rev => rev.id === review.id);
             review.status = updatedReview.status;
             review.comment = updatedReview.comment;
-        } while (reviewPending(review) && pollCount < 20);
+        } while (reviewPending(review) && pollCount < 100);
 
         if (reviewPending(review)) {
             // Max polls reached


### PR DESCRIPTION
This pr increases the wait time for plugin binary reviews. Currently it will only wait for a minute to complete. The new limit is 5 minutes.