### PR TITLE
Add compatibility for Shopware's new 4 digit version number

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -75,7 +75,7 @@ module.exports = class Plugin {
         }
 
         if (this.shopwareMajorVersion === 6) {
-            if (!shopwareMarketingVersion.startsWith("6.")) {
+            if (!shopwareMarketingVersion.startsWith('6.')) {
                 return false;
             }
 
@@ -83,32 +83,33 @@ module.exports = class Plugin {
             const pluginShopwareCompatibility = this.getShopware6Semver(this.shopwareCompatibility);
 
             return semver.satisfies(shopwareVersion, pluginShopwareCompatibility);
-        } else if (this.shopwareMajorVersion === 5) {
-            if (!shopwareMarketingVersion.startsWith("5.")) {
+        }
+
+        if (this.shopwareMajorVersion === 5) {
+            if (!shopwareMarketingVersion.startsWith('5.')) {
                 return false;
             }
 
             return semver.satisfies(shopwareMarketingVersion, this.shopwareCompatibility);
-        } else {
-            throw new Error(
-                'The scs-commander is incompatible with the given Shopware version number'
-                +` (${shopwareMarketingVersion}).`
-            );
         }
+
+        throw new Error(
+            'The scs-commander is incompatible with the given Shopware version number'
+                + ` (${shopwareMarketingVersion}).`,
+        );
     }
 
     getShopware6Semver(version) {
-        if (!version.startsWith("6.")) {
-            throw new Error("No Shopware 6 version number given.");
+        if (!version.startsWith('6.')) {
+            throw new Error('No Shopware 6 version number given.');
         }
 
-        const versionPieces = version.split(".").length + 1;
+        const versionPieces = version.split('.').length + 1;
         if (versionPieces === 4) {
             return version.substring(2);
-        } else if (versionPieces === 3) {
+        } if (versionPieces === 3) {
             return `${version.substring(2)}.0`;
-        } else {
-            throw new Error('The given shopware version format is unknown.');
         }
+        throw new Error('The given shopware version format is unknown.');
     }
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -95,7 +95,7 @@ module.exports = class Plugin {
 
         throw new Error(
             'The scs-commander is incompatible with the given Shopware version number'
-                + ` (${shopwareMarketingVersion}).`,
+            + ` (${shopwareMarketingVersion}).`,
         );
     }
 
@@ -104,10 +104,12 @@ module.exports = class Plugin {
             throw new Error('No Shopware 6 version number given.');
         }
 
-        const versionPieces = version.split('.').length + 1;
-        if (versionPieces === 4) {
+        const numberOfVersionComponents = version.split('.').length;
+        if (numberOfVersionComponents === 4) {
             return version.substring(2);
-        } if (versionPieces === 3) {
+        }
+
+        if (numberOfVersionComponents === 3) {
             return `${version.substring(2)}.0`;
         }
         throw new Error('The given shopware version format is unknown.');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -69,7 +69,46 @@ module.exports = class Plugin {
         return plugin;
     }
 
-    isCompatibleWithShopwareVersion(shopwareVersion) {
-        return semver.satisfies(shopwareVersion, this.shopwareCompatibility);
+    isCompatibleWithShopwareVersion(shopwareMarketingVersion) {
+        if (!shopwareMarketingVersion) {
+            return false;
+        }
+
+        if (this.shopwareMajorVersion === 6) {
+            if (!shopwareMarketingVersion.startsWith("6.")) {
+                return false;
+            }
+
+            const shopwareVersion = this.getShopware6Semver(shopwareMarketingVersion);
+            const pluginShopwareCompatibility = this.getShopware6Semver(this.shopwareCompatibility);
+
+            return semver.satisfies(shopwareVersion, pluginShopwareCompatibility);
+        } else if (this.shopwareMajorVersion === 5) {
+            if (!shopwareMarketingVersion.startsWith("5.")) {
+                return false;
+            }
+
+            return semver.satisfies(shopwareMarketingVersion, this.shopwareCompatibility);
+        } else {
+            throw new Error(
+                'The scs-commander is incompatible with the given Shopware version number'
+                +` (${shopwareMarketingVersion}).`
+            );
+        }
+    }
+
+    getShopware6Semver(version) {
+        if (!version.startsWith("6.")) {
+            throw new Error("No Shopware 6 version number given.");
+        }
+
+        const versionPieces = version.split(".").length + 1;
+        if (versionPieces === 4) {
+            return version.substring(2);
+        } else if (versionPieces === 3) {
+            return `${version.substring(2)}.0`;
+        } else {
+            throw new Error('The given shopware version format is unknown.');
+        }
     }
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -101,17 +101,20 @@ module.exports = class Plugin {
 
     getShopware6Semver(version) {
         if (!version.startsWith('6.')) {
-            throw new Error('No Shopware 6 version number given.');
+            throw new Error(`"${version}" is not a valid Shopware 6 version number.`);
         }
 
         const numberOfVersionComponents = version.split('.').length;
         if (numberOfVersionComponents === 4) {
+            // "New", 4-component version (e.g. `6.3.0.0`). Hence just drop the first component.
             return version.substring(2);
         }
 
         if (numberOfVersionComponents === 3) {
+            // Legacy version (e.g. `6.1.0`). Hence drop the first component and add a patch version of `0`.
             return `${version.substring(2)}.0`;
         }
+
         throw new Error('The given shopware version format is unknown.');
     }
 };


### PR DESCRIPTION
## Summary

Shopware just changed their version schema to a semantic versioning prefixed by `6.` for the generation. This leads the scs-commander to crash when uploading a new version of any (Shopware 5 or 6) plugin.

Unfortunately, the `semver` library is not compatible with 4 digit version numbers (see also: https://github.com/semver/semver/issues/213#issuecomment-642236371). Furthermore, I could not find a high quality library to replace `semver`. As a result, I adjusted the compatibility calculation in this pr so that the commander is compatible with the new versioning schema.