### PR TITLE
Increase maximum upload limit for binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next patch release
+
+* Increase maximum file upload size to 30MB.
+
 ## 3.0.1
 
 * Fixes usages of options passed to any command.

--- a/lib/client/shopwareStoreClient.js
+++ b/lib/client/shopwareStoreClient.js
@@ -4,6 +4,7 @@ const retryInterceptor = require('./retryInterceptor');
 
 const baseURL = 'https://api.shopware.com/';
 const timeout = 2 * 60 * 1000; // 2 minutes
+const maxBodyLength = 30 * (1024 ** 2); // 30MB
 
 /**
  * Create the axios instance, attach the emitter to it and register all interceptors.
@@ -15,6 +16,7 @@ module.exports = (emitter) => {
     const customAxios = axios.create({
         baseURL,
         timeout,
+        maxBodyLength,
     });
     customAxios.emitter = emitter;
     spinnerInterceptors(customAxios);


### PR DESCRIPTION
Currently the limit for uploading files is 10MB and Shopware increased the maximum size für binaries a while ago to 30MB.

This PR changes the limit to allow uploading files up to the maximum size that Shopware allows.

Closes #42 