### PR TITLE
Use >= compatibility for engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "viison-style-guide": "git+https://github.com/pickware/style-guide.git"
     },
     "engines": {
-        "node": "^14.0.0"
+        "node": ">=14.0.0"
     },
     "preferGlobal": true
 }


### PR DESCRIPTION
The `engines.node` specification in `package.json` should always use `>=` instead of `^` to enable automatic compatibility with new major versions of node. As node generally doesn't break source code compatibility with major versions, this is fine.

closes #45 